### PR TITLE
Corriger l'erreur dans le module de vol

### DIFF
--- a/modules/flight.py
+++ b/modules/flight.py
@@ -1,5 +1,6 @@
 # Page des informations de vol
 import streamlit as st
+from datetime import datetime
 from data.models import get_default_flight_info
 from data.storage import sync_state
 


### PR DESCRIPTION
Add `datetime` import to `flight.py` to resolve `datetime.strptime` usage error.